### PR TITLE
Use rlang instead of ellipsis for dot checking

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,16 +17,14 @@ Imports:
     ggplot2 (>= 3.1.1),
     stringr (>= 1.4.0),
     purrr (>= 0.3.2),
-    rlang (>= 0.3.4),
+    rlang (>= 1.0.0),
     fpc (>= 2.1-11.1),
     Rcpp (>= 1.0.1),
-    hardhat,
-    ellipsis
+    hardhat
 RoxygenNote: 7.2.3
 Suggests: 
     testthat (>= 3.0.0),
     rmarkdown (>= 1.18),
-    covr (>= 3.2.1),
     mlbench (>= 2.1-1),
     dplyr (>= 0.8.0.1),
     magrittr (>= 1.5),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # dann v 1.0.1
   Link github in description.
   Update actions.
+  Remove ellipsis dependency for rlang for ... check.
   
 # dann v 1.0.0
   Adding linter.

--- a/R/dann.R
+++ b/R/dann.R
@@ -266,7 +266,7 @@ dann.default <- function(x, k = 5, neighborhood_size = max(floor(nrow(x) / 5), 5
 #' dann(x, y)
 #' @export
 dann.data.frame <- function(x, y, k = 5, neighborhood_size = max(floor(nrow(x) / 5), 50), epsilon = 1, ...) {
-  ellipsis::check_dots_empty()
+  rlang::check_dots_empty()
   processed <- hardhat::mold(x, y)
   dann_bridge(processed, k, neighborhood_size, epsilon)
 }
@@ -294,7 +294,7 @@ dann.data.frame <- function(x, y, k = 5, neighborhood_size = max(floor(nrow(x) /
 #' dann(x, y)
 #' @export
 dann.matrix <- function(x, y, k = 5, neighborhood_size = max(floor(nrow(x) / 5), 50), epsilon = 1, ...) {
-  ellipsis::check_dots_empty()
+  rlang::check_dots_empty()
   processed <- hardhat::mold(x, y)
   dann_bridge(processed, k, neighborhood_size, epsilon)
 }
@@ -320,7 +320,7 @@ dann.matrix <- function(x, y, k = 5, neighborhood_size = max(floor(nrow(x) / 5),
 #' dann(Y ~ X1 + X2, train)
 #' @export
 dann.formula <- function(formula, data, k = 5, neighborhood_size = max(floor(nrow(data) / 5), 50), epsilon = 1, ...) {
-  ellipsis::check_dots_empty()
+  rlang::check_dots_empty()
   hardhat::validate_no_formula_duplication(formula = formula, original = TRUE)
   processed <- hardhat::mold(formula, data)
   dann_bridge(processed, k, neighborhood_size, epsilon)
@@ -350,7 +350,7 @@ dann.formula <- function(formula, data, k = 5, neighborhood_size = max(floor(nro
 #' dann(rec_obj, train)
 #' @export
 dann.recipe <- function(x, data, k = 5, neighborhood_size = max(floor(nrow(data) / 5), 50), epsilon = 1, ...) {
-  ellipsis::check_dots_empty()
+  rlang::check_dots_empty()
   processed <- hardhat::mold(x, data)
   dann_bridge(processed, k, neighborhood_size, epsilon)
 }
@@ -555,7 +555,7 @@ predict_dann_bridge <- function(type, object, predictors) {
 #' @importFrom stats predict
 #' @export
 predict.dann <- function(object, new_data, type = "class", ...) {
-  ellipsis::check_dots_empty()
+  rlang::check_dots_empty()
 
   processed <- hardhat::forge(new_data, object$blueprint)
 

--- a/R/graph_eigenvalues.R
+++ b/R/graph_eigenvalues.R
@@ -169,7 +169,7 @@ graph_eigenvalues.default <- function(x, neighborhood_size = max(floor(nrow(x) /
 #' graph_eigenvalues(x, y)
 #' @export
 graph_eigenvalues.data.frame <- function(x, y, neighborhood_size = max(floor(nrow(x) / 5), 50), weighted = FALSE, sphere = "mcd", ...) {
-  ellipsis::check_dots_empty()
+  rlang::check_dots_empty()
   processed <- hardhat::mold(x, y)
   graph_eigenvalues_bridge(processed, neighborhood_size, weighted, sphere)
 }
@@ -208,7 +208,7 @@ graph_eigenvalues.data.frame <- function(x, y, neighborhood_size = max(floor(nro
 #' graph_eigenvalues(x, y)
 #' @export
 graph_eigenvalues.matrix <- function(x, y, neighborhood_size = max(floor(nrow(x) / 5), 50), weighted = FALSE, sphere = "mcd", ...) {
-  ellipsis::check_dots_empty()
+  rlang::check_dots_empty()
   processed <- hardhat::mold(x, y)
   graph_eigenvalues_bridge(processed, neighborhood_size, weighted, sphere)
 }
@@ -244,7 +244,7 @@ graph_eigenvalues.matrix <- function(x, y, neighborhood_size = max(floor(nrow(x)
 #' graph_eigenvalues(Y ~ X1 + X2 + U1 + U2 + U3 + U4 + U5, train)
 #' @export
 graph_eigenvalues.formula <- function(formula, data, neighborhood_size = max(floor(nrow(data) / 5), 50), weighted = FALSE, sphere = "mcd", ...) {
-  ellipsis::check_dots_empty()
+  rlang::check_dots_empty()
   hardhat::validate_no_formula_duplication(formula = formula, original = TRUE)
   processed <- hardhat::mold(formula, data)
   graph_eigenvalues_bridge(processed, neighborhood_size, weighted, sphere)
@@ -284,7 +284,7 @@ graph_eigenvalues.formula <- function(formula, data, neighborhood_size = max(flo
 #' graph_eigenvalues(rec_obj, train)
 #' @export
 graph_eigenvalues.recipe <- function(x, data, neighborhood_size = max(floor(nrow(data) / 5), 50), weighted = FALSE, sphere = "mcd", ...) {
-  ellipsis::check_dots_empty()
+  rlang::check_dots_empty()
   processed <- hardhat::mold(x, data)
   graph_eigenvalues_bridge(processed, neighborhood_size, weighted, sphere)
 }

--- a/R/sub_dann.R
+++ b/R/sub_dann.R
@@ -312,7 +312,7 @@ sub_dann.default <- function(x, k = 5, neighborhood_size = max(floor(nrow(x) / 5
 #' sub_dann(x, y)
 #' @export
 sub_dann.data.frame <- function(x, y, k = 5, neighborhood_size = max(floor(nrow(x) / 5), 50), epsilon = 1, weighted = FALSE, sphere = "mcd", numDim = ceiling(ncol(x) / 2), ...) {
-  ellipsis::check_dots_empty()
+  rlang::check_dots_empty()
   processed <- hardhat::mold(x, y)
   sub_dann_bridge(processed, k, neighborhood_size, epsilon, weighted, sphere, numDim)
 }
@@ -340,7 +340,7 @@ sub_dann.data.frame <- function(x, y, k = 5, neighborhood_size = max(floor(nrow(
 #' sub_dann(x, y)
 #' @export
 sub_dann.matrix <- function(x, y, k = 5, neighborhood_size = max(floor(nrow(x) / 5), 50), epsilon = 1, weighted = FALSE, sphere = "mcd", numDim = ceiling(ncol(x) / 2), ...) {
-  ellipsis::check_dots_empty()
+  rlang::check_dots_empty()
   processed <- hardhat::mold(x, y)
   sub_dann_bridge(processed, k, neighborhood_size, epsilon, weighted, sphere, numDim)
 }
@@ -366,7 +366,7 @@ sub_dann.matrix <- function(x, y, k = 5, neighborhood_size = max(floor(nrow(x) /
 #' sub_dann(Y ~ X1 + X2, train)
 #' @export
 sub_dann.formula <- function(formula, data, k = 5, neighborhood_size = max(floor(nrow(data) / 5), 50), epsilon = 1, weighted = FALSE, sphere = "mcd", numDim = ceiling(ncol(data) / 2), ...) {
-  ellipsis::check_dots_empty()
+  rlang::check_dots_empty()
   hardhat::validate_no_formula_duplication(formula = formula, original = TRUE)
   processed <- hardhat::mold(formula, data)
   sub_dann_bridge(processed, k, neighborhood_size, epsilon, weighted, sphere, numDim)
@@ -396,7 +396,7 @@ sub_dann.formula <- function(formula, data, k = 5, neighborhood_size = max(floor
 #' sub_dann(rec_obj, train)
 #' @export
 sub_dann.recipe <- function(x, data, k = 5, neighborhood_size = max(floor(nrow(data) / 5), 50), epsilon = 1, weighted = FALSE, sphere = "mcd", numDim = ceiling(ncol(data) / 2), ...) {
-  ellipsis::check_dots_empty()
+  rlang::check_dots_empty()
   processed <- hardhat::mold(x, data)
   sub_dann_bridge(processed, k, neighborhood_size, epsilon, weighted, sphere, numDim)
 }
@@ -496,7 +496,7 @@ predict_sub_dann_bridge <- function(type, object, predictors) {
 #' @importFrom stats predict
 #' @export
 predict.sub_dann <- function(object, new_data, type = "class", ...) {
-  ellipsis::check_dots_empty()
+  rlang::check_dots_empty()
 
   processed <- hardhat::forge(new_data, object$blueprint)
 


### PR DESCRIPTION
Since ellipsis is deprecated / superseded  https://rlang.r-lib.org/news/index.html#argument-intake-1-0-0

Since covr is installed on the test-coverage action, there is no need to suggest it. 

FYI, if you want to repair the test-coverage action, you may want to follow the steps at https://github.com/r-lib/actions/issues/834 i.e. create a codecov token